### PR TITLE
Fix minor errors in fedora_manual_config.md

### DIFF
--- a/content/en/docs/getting-started-guides/fedora/fedora_manual_config.md
+++ b/content/en/docs/getting-started-guides/fedora/fedora_manual_config.md
@@ -122,10 +122,9 @@ KUBELET_HOSTNAME="--hostname-override=fed-node"
 # location of the api-server
 KUBELET_ARGS="--cgroup-driver=systemd --kubeconfig=/etc/kubernetes/master-kubeconfig.yaml --require-kubeconfig"
 
-# Add your own!
-KUBELET_ARGS=""
-
 ```
+
+And add new config file `/etc/kubernetes/master-kubeconfig.yaml` with content:
 
 ```yaml
 kind: Config


### PR DESCRIPTION
This fix is basically for a few errors caused by #7417 . To complete #7417, following errors should be fixed:
- duplicated KUBELET_ARGS arg declaration should be deleted
- what to do about yaml should be explained

>^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> For 1.11 Features: set Milestone to 1.11 and Base Branch to release-1.11
>^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> NOTE: After opening the PR, please *un-check and re-check* the ["Allow edits from maintainers"](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) box so that maintainers can work on your patch and speed up the review process. This is a temporary workaround to address a known issue with GitHub.> 
>
> Please delete this note before submitting the pull request.

![Allow edits from maintainers checkbox](https://help.github.com/assets/images/help/pull_requests/allow-maintainers-to-make-edits-sidebar-checkbox.png)
